### PR TITLE
年初来高値を更新した銘柄一覧のスクレイピングの単体テスト

### DIFF
--- a/scraping/kabutan/kabutan_test.go
+++ b/scraping/kabutan/kabutan_test.go
@@ -1,0 +1,40 @@
+package kabutan
+
+import (
+	"testing"
+)
+
+func TestScraping(t *testing.T) {
+	dataList := Scraping()
+	for _, year_high := range dataList.YearHigh {
+		code := year_high.Code
+		if code == "" {
+			t.Errorf("code is not get")
+		}
+
+		name := year_high.Name
+		if name == "" {
+			t.Errorf("name is not get")
+		}
+
+		market := year_high.Market
+		if market == "" {
+			t.Errorf("market is not get")
+		}
+
+		price := year_high.Price
+		if price == "" {
+			t.Errorf("price is not get")
+		}
+
+		diff_price := year_high.DiffPrice
+		if diff_price == "" {
+			t.Errorf("diff_price is not get")
+		}
+
+		ratio_price := year_high.RatioPrice
+		if ratio_price == "" {
+			t.Errorf("ratio_price is not get")
+		}
+	}
+}


### PR DESCRIPTION
issue: #4

年初来高値のスクレイピングのテストの実装を行いました。

テストで確認している項目は以下の通りです。

- 年初来高値を更新している銘柄の、銘柄コード、銘柄名、市場名、株価、株価変化、株価変化率、が値を持っているかの確認